### PR TITLE
Changes to support auth token req validation #448

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -81,6 +81,11 @@ h4. Basic Authentication
 elasticsearch-head will add basic auth headers to each request if you pass in the "correct url parameters":#url-parameters
 You will also need to add @http.cors.allow-headers: Authorization@ to the elasticsearch configuration
 
+h4. Token or JWT Authentication
+
+elasticsearch-head will add token headers to each request if you pass token in the input text box besides URL.
+It sends each request with header in the format "Authorization: Bearer ${token}".
+
 h4. x-pack
 
 elasticsearch x-pack requires basic authentication _and_ CORS as described above. Make sure you have the correct CORS setup and then open es-head with a url like "http://localhost:9100/?auth_user=elastic&auth_password=changeme"

--- a/README.textile
+++ b/README.textile
@@ -83,7 +83,7 @@ You will also need to add @http.cors.allow-headers: Authorization@ to the elasti
 
 h4. Token or JWT Authentication
 
-elasticsearch-head will add token headers to each request if you pass token in the input text box besides URL.
+elasticsearch-head will add token in headers of each request if you pass token in the input text box besides URL.
 It sends each request with header in the format "Authorization: Bearer ${token}".
 
 h4. x-pack


### PR DESCRIPTION
elasticsearch-head will add token in headers of each request if you pass token in the input text box besides URL.
It sends each request with header in the format "Authorization: Bearer ${token}".

PR has only _site changes for now. In further  PRs will add changes for the /app. 

![auth-token-ui](https://user-images.githubusercontent.com/25893484/105634313-65686800-5e83-11eb-8e8b-16ab1b499127.PNG)

